### PR TITLE
fixed lua errors occuring since 11 oct 2023 in wotlk classic

### DIFF
--- a/DingClassic/DingClassic.xml
+++ b/DingClassic/DingClassic.xml
@@ -1,9 +1,6 @@
 <Ui xmlns="http://www.w3.org/2001/XMLSchema-instance">
     <Script file="DingClassic.lua"/>
-    <Frame name="DingClassicOptionsPanel" parent="InterfaceOptionsPanelTemplate">
-        <Scripts>
-            <OnLoad function="DingClassicOptionsPanel_OnLoad"/>
-        </Scripts>
+    <Frame name="DingClassicOptionsPanel">        
         <CheckButton name="DingClassicOptionsPanelCheckbox" inherits="InterfaceOptionsCheckButtonTemplate">
             <Anchors>
                 <Anchor point="TOPLEFT" relativeTo="$parent" relativePoint="TOPLEFT" x="10" y="-10"/>


### PR DESCRIPTION
It seems new wotlk classic client is more picky about missing objects. Having errors about:

- parent="InterfaceOptionsPanelTemplate" is missing
- function="DingClassicOptionsPanel_OnLoad" is missing

Removed both references, seems working all right without them.
Also tested in Pandaria 5.4.8, no errors after the fix.